### PR TITLE
fix: deliver contact-change events on the platform thread

### DIFF
--- a/ios/Classes/SwiftFlutterContactsPlugin.swift
+++ b/ios/Classes/SwiftFlutterContactsPlugin.swift
@@ -760,7 +760,7 @@ public class SwiftFlutterContactsPlugin: NSObject, FlutterPlugin, FlutterStreamH
         NotificationCenter.default.addObserver(
             forName: NSNotification.Name.CNContactStoreDidChange,
             object: nil,
-            queue: nil,
+            queue: OperationQueue.main,
             using: { _ in events([]) }
         )
         return nil


### PR DESCRIPTION
## Summary
- `CNContactStoreDidChange` observers registered with `queue: nil` run on whatever thread posts the notification, so the `FlutterEventSink` was invoked off the platform thread. The Flutter engine logs "Platform channel messages must be sent on the platform thread … may result in data loss or crashes" for exactly this, and in practice it corrupts the binary messenger: responses to in-flight method-channel calls (e.g. a bulk `getContacts` of ~5,000 contacts) are silently dropped and the Dart `await` never completes.
- Delivering the observer on `OperationQueue.main` puts the sink back on the platform thread.

## Test plan
- [ ] In the DContact app on a simulator with ~5,000 contacts: trigger phone-book changes (sync push), then run a restore — the bulk `getContacts` completes instead of hanging, and the engine's non-platform-thread warning no longer appears
- [ ] Change-history events still arrive after phone-book edits
